### PR TITLE
Add fan mode 'follow schedule'

### DIFF
--- a/somecomfort/client.py
+++ b/somecomfort/client.py
@@ -7,7 +7,7 @@ import time
 
 
 _LOG = logging.getLogger('somecomfort')
-FAN_MODES = ['auto', 'on', 'circulate']
+FAN_MODES = ['auto', 'on', 'circulate', 'follow schedule']
 SYSTEM_MODES = ['unknown', 'heat', 'off', 'cool', 'auto', 'auto']
 HOLD_TYPES = ['schedule', 'temporary', 'permanent']
 
@@ -125,7 +125,7 @@ class Device(object):
         """Returns one of FAN_MODES indicating the current setting"""
         try:
             return FAN_MODES[self._data['fanData']['fanMode']]
-        except (KeyError, TypeError):
+        except (KeyError, TypeError, IndexError):
             if self._data['hasFan']:
                 raise APIError(
                     'Unknown fan mode %i' % self._data['fanData']['fanMode'])


### PR DESCRIPTION
The fan mode array is missing a mode. When the fan mode is set to **follow schedule** on a US thermostat, Device.fan_mode() raises an out of range exception.
The fan mode **follow schedule** is equal to 3.

Here are the current fan modes for the US thermostat:
<img src="https://cloud.githubusercontent.com/assets/1936814/20452524/9945fc32-add9-11e6-821d-17f2722b58cd.png" width="300">

This commit adds the new mode, and handles the IndexError exception.