### PR TITLE
Fix exception in equipment output status when equipment is idle

### DIFF
--- a/somecomfort/client.py
+++ b/somecomfort/client.py
@@ -265,7 +265,7 @@ class Device(object):
     @property
     def equipment_output_status(self):
         """The current equipment output status"""
-        if self._data['uiData']['EquipmentOutputStatus'] == 0:
+        if self._data['uiData']['EquipmentOutputStatus'] in (0, None):
             if self.fan_running:
                 return "fan"
             else:


### PR DESCRIPTION
When the equipment is idle or stopped, the variable EquipmentOutputStatus is set to None.
This value led to the following exception:
```
  Traceback (most recent call last):
    File "/usr/local/bin/somecomfort", line 9, in <module>
      load_entry_point('somecomfort==0.4.1', 'console_scripts', 'somecomfort')()
    File "build/bdist.linux-x86_64/egg/somecomfort/__main__.py", line 199, in main
    File "build/bdist.linux-x86_64/egg/somecomfort/__main__.py", line 192, in _main
    File "build/bdist.linux-x86_64/egg/somecomfort/__main__.py", line 33, in get_or_set_things
    File "build/bdist.linux-x86_64/egg/somecomfort/client.py", line 275, in equipment_output_status
  TypeError: list indices must be integers, not NoneType
```

This commit adds the support to handle 'None' as 0.