### PR TITLE
Add indoor humidity, and outdoor temperature & humidity

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,10 +20,12 @@ Installing
                      [--set_setpoint_cool SET_SETPOINT_COOL]
                      [--get_setpoint_heat]
                      [--set_setpoint_heat SET_SETPOINT_HEAT]
-                     [--get_current_temperature] [--cancel_hold]
-                     [--permanent_hold] [--hold_until HOLD_UNTIL] [--get_hold]
+                     [--get_current_temperature] [--get_current_humidity]
+                     [--get_equipment_output_status] [--get_outdoor_temperature]
+                     [--get_outdoor_humidity] [--cancel_hold] [--permanent_hold]
+                     [--hold_until HOLD_UNTIL] [--get_hold]
                      [--username USERNAME] [--password PASSWORD]
-                     [--device DEVICE] [--login]
+                     [--device DEVICE] [--login] [--devices]
   
   optional arguments:
     -h, --help            show this help message and exit
@@ -41,6 +43,14 @@ Installing
                           Set setpoint_heat
     --get_current_temperature
                           Get current_temperature
+    --get_current_humidity
+                          Get current_humidity
+    --get_equipment_output_status
+                          Get equipment_output_status
+    --get_outdoor_temperature
+                          Get outdoor_temperature
+    --get_outdoor_humidity
+                          Get outdoor_humidity
     --cancel_hold         Set cancel_hold
     --permanent_hold      Set permanent_hold
     --hold_until HOLD_UNTIL
@@ -50,6 +60,7 @@ Installing
     --password PASSWORD   password
     --device DEVICE       device
     --login               Just try to login
+    --devices             List available devices
 
 Using
 -----

--- a/somecomfort/__main__.py
+++ b/somecomfort/__main__.py
@@ -107,7 +107,7 @@ def _main(session):
     string_things = ['fan_mode', 'system_mode']
     bool_things = ['cancel_hold', 'permanent_hold']
     settable_things = {float: number_things, str: string_things}
-    readonly_things = ['current_temperature', 'equipment_output_status']
+    readonly_things = ['current_temperature', 'current_humidity', 'equipment_output_status', 'outdoor_temperature', 'outdoor_humidity']
     parser = argparse.ArgumentParser()
     for thingtype, thinglist in settable_things.items():
         for thing in thinglist:

--- a/somecomfort/client.py
+++ b/somecomfort/client.py
@@ -263,6 +263,11 @@ class Device(object):
         return self._data['uiData']['DispTemperature']
 
     @property
+    def current_humidity(self):
+        """The current measured ambient humidity"""
+        return self._data['uiData']['IndoorHumidity']
+
+    @property
     def equipment_output_status(self):
         """The current equipment output status"""
         if self._data['uiData']['EquipmentOutputStatus'] in (0, None):
@@ -271,6 +276,20 @@ class Device(object):
             else:
                 return "off"
         return EQUIPMENT_OUTPUT_STATUS[self._data['uiData']['EquipmentOutputStatus']]
+
+    @property
+    def outdoor_temperature(self):
+        """The current measured outdoor temperature"""
+        if self._data['uiData']['OutdoorTemperatureAvailable'] == True:
+            return self._data['uiData']['OutdoorTemperature']
+        return None
+
+    @property
+    def outdoor_humidity(self):
+        """The current measured outdoor humidity"""
+        if self._data['uiData']['OutdoorHumidityAvailable'] == True:
+            return self._data['uiData']['OutdoorHumidity']
+        return None
 
     @property
     def temperature_unit(self):


### PR DESCRIPTION
  - Add indoor humidity with `--get_current_humidity`.
  - Add outdoor temperature with `--get_outdoor_temperature`.
  - Add outdoor humidity with `--get_outdoor_humidity`.
  - Update README with new and missing options.

  Note: To query outdoor data, the outdoor sensor is required.
        Routines for outdoor data test availability of the outdoor sensor.
        If sensor is not found, then `None` is returned, otherwise sensor value is returned.

_Implemente feature requested in issue #12_